### PR TITLE
添加 docker-compose 部署方式 & 第三方镜像站链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## 介绍 💨
 
 ### [Jetpack Compose Book](https://jetpackcompose.cn/)
+国内第三方镜像 *（加载速度快，内容可能略滞后于官网）*：[https://compose.funnysaltyfish.fun](https://compose.funnysaltyfish.fun)
 
 此项目致力于帮助大家更好的认识 Jetpack Compose 框架, 更多的部分是为了补充官网可能没有介绍的东西。
 
@@ -28,20 +29,54 @@
 
 ### 在本地编辑&测试
 
-前置条件：
+#### 基于 Docker 部署
+> Docker 是一个开源的应用容器引擎，让开发者可以打包他们的应用以及依赖包到一个可移植的容器中，然后发布到任何环境中
+
+1. 安装 [Docker](https://docs.docker.com/get-docker/) 和 [Docker Compose](https://docs.docker.com/compose/install/)
+
+2. 新建目录用于存放 docker-compose.yml 文件和项目文件
+3. 在目录下新建 docker-compose.yml 文件，内容如下：
+```yaml
+version: "3.7"
+
+services:
+  docusaurus:
+    container_name: docusaurus
+    image: awesometic/docusaurus
+    volumes:
+      - ./jetpack-compose-book-master:/docusaurus/website
+    environment:
+      - TZ=Asia/Shanghai
+      - AUTO_UPDATE=false
+      - WEBSITE_NAME=website
+      - RUN_MODE=development # development or production
+    ports:
+      - 3000:80
+
+```
+4. clone 或 Download Zip 下载本项目源码到本地，重命名为 `jetpack-compose-book-master`，放到此目录下。此时，目录结构如下
+```
+.
+├── docker-compose.yml
+└── jetpack-compose-book-master
+  ├── README.md
+  ...
+```
+5. 在此目录下打开终端，执行 `docker-compose up -d`（部分 linux 平台命令为 docker compose up -d，下面类似）（-d 意为后台运行，如果首次运行希望看到输出，可以不加 -d），稍等几分钟后将会在 [`http://localhost:3000/`](http://localhost:3000/) 看到文档
+6. 如果想要停止运行并删除容器，执行 `docker-compose down`；如果更新了文件，可以使用 `docker-compose restart` 重启容器；如果想发布生产版本，请将 `docker-compose.yml` 中的 `RUN_MODE` 改为 `production`，并执行 `docker-compose stop && docker-compose up -d` 重启容器，执行完成后可在 `./jetpack-compose-book-master/build` 下看到生成的静态文件
+
+
+#### 基于本地环境部署
+当然，你也可以在本地环境部署，此方式对 Node.js 和 npm 的版本有较严格要求，如下：
 1. [Node.js](https://nodejs.org/en/download/) >= 16.14
 2. npm 推荐 8.12 左右
 
 
-#### 1. fork 仓库
-
-```
-npm install
-```
+环境安装完后，fork 仓库并在项目目录执行 `npm install` 以安装依赖。
 
 在项目根目录终端执行 `npm run start`，将会在 [`http://localhost:3000/`](http://localhost:3000/) 看到文档
 
-#### 2. 如何添加/更改文档？
+#### 如何添加/更改文档？
     
 文档都是由 **Markdown** 语法来编写的，所有文档位于 [/docs](https://github.com/compose-museum/compose-tutorial/tree/master/docs) 中, 如果需要扩展左边的侧边栏，请在 [**sidebars.js**](sidebars.js) 更新。
 
@@ -49,7 +84,7 @@ npm install
 
 [调用图片方法](https://docusaurus.io/zh-CN/docs/static-assets)
 
-#### 3. 测试
+#### 如何测试
 
 运行 `npm run build` 会生成 `build` 文件夹，期间 `docusaurus` 会打印日志告诉你是否有 WARNING 或者 ERROR（一般可能是路径错误等）
 


### PR DESCRIPTION
只更改 `README.md`，鉴于项目实在是太难跑起来了，折腾一下午，添加了 docker-compose 部署的方式，并把它部署到了我自己的服务器上，作为第三方镜像链接添加至项目中